### PR TITLE
#5 JWTによる認証を実装

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 	"workspaceFolder": "/go/src",
 	"settings": {},
 	"extensions": [
-		"golang.go"
+		"golang.go",
+		"42crunch.vscode-openapi"
 	]
 }

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ GO_ENV = test
 # PG DEVELOPMENT ENV
 #########################
 DATABASE_URI = test:test@tcp(db:3306)/todo?charset=utf8&parseTime=true&loc=Asia%2FTokyo
+
+
+JWT_SECRET = 

--- a/controllers/user/getList/repository.go
+++ b/controllers/user/getList/repository.go
@@ -1,0 +1,45 @@
+package getlist
+
+import (
+	"database/sql"
+	"log"
+
+	model "github.com/Yuki-TU/todo-go/models"
+)
+
+type Repository interface {
+	UsersRepository() (*[]model.EntityUsers, string)
+}
+
+type repository struct {
+	// DBハンドラーインスタンス
+	db *sql.DB
+}
+
+func NewRepositoryUserList(db *sql.DB) *repository {
+	return &repository{db: db}
+}
+
+// DBに対してでユーザ登録登録を行う
+// @params input 登録情報
+func (r *repository) UsersRepository() (*[]model.EntityUsers, string) {
+	errorCode := make(chan string, 1)
+
+	var userList []model.EntityUsers
+	rows, err := r.db.Query(`SELECT id, fullname, email, active, createdAt, updatedAt FROM users`)
+	for rows.Next() {
+		user := model.EntityUsers{}
+		if err := rows.Scan(&user.ID, &user.Fullname, &user.Email, &user.Active, &user.UpdatedAt, &user.CreatedAt); err != nil {
+			log.Fatal(err)
+		}
+		userList = append(userList, user)
+	}
+
+	// ユーザ登録
+	if err != nil {
+		errorCode <- "USERLIST_NOT_FOUND_404"
+		return &userList, <-errorCode
+	}
+	errorCode <- "nil"
+	return &userList, <-errorCode
+}

--- a/controllers/user/getList/service.go
+++ b/controllers/user/getList/service.go
@@ -1,0 +1,28 @@
+package getlist
+
+import (
+	model "github.com/Yuki-TU/todo-go/models"
+)
+
+type Service interface {
+	GetUserListService() (*[]model.EntityUsers, string)
+}
+
+type service struct {
+	repository Repository
+}
+
+func NewServiceRegister(repository Repository) *service {
+	return &service{repository: repository}
+}
+
+// ハンドラーとリポジトリをつなげる
+// @params input POSTデータ
+//
+// @return resultRegister 登録結果
+//
+// @return errRegister 登録の際発生したエラー
+func (s *service) GetUserListService() (*[]model.EntityUsers, string) {
+	resultRegister, errRegister := s.repository.UsersRepository()
+	return resultRegister, errRegister
+}

--- a/controllers/user/login/input.go
+++ b/controllers/user/login/input.go
@@ -1,0 +1,6 @@
+package loginAuth
+
+type InputLogin struct {
+	Email    string `json:"email" validate:"required,email"`
+	Password string `json:"password" validate:"required"`
+}

--- a/controllers/user/login/repository.go
+++ b/controllers/user/login/repository.go
@@ -1,0 +1,49 @@
+package loginAuth
+
+import (
+	"database/sql"
+
+	model "github.com/Yuki-TU/todo-go/models"
+	util "github.com/Yuki-TU/todo-go/utils"
+)
+
+type Repository interface {
+	LoginRepository(input *model.EntityUsers) (*model.EntityUsers, string)
+}
+
+type repository struct {
+	db *sql.DB
+}
+
+func NewRepositoryLogin(db *sql.DB) *repository {
+	return &repository{db: db}
+}
+
+// ログイン確認処理
+// @params input 入力した値(email, password)
+//
+// @return ユーザ情報, エラーコード
+func (r *repository) LoginRepository(input *model.EntityUsers) (*model.EntityUsers, string) {
+	errorCode := make(chan string, 1)
+
+	var user model.EntityUsers
+
+	row := r.db.QueryRow(`SELECT * FROM users where email = ? LIMIT 1`, input.Email)
+	err := row.Scan(&user.ID, &user.Fullname, &user.Email, &user.Password, &user.Active, &user.UpdatedAt, &user.CreatedAt)
+
+	// アカウントが見つからない
+	if err != nil {
+		errorCode <- "LOGIN_NOT_FOUND_404"
+		return input, <-errorCode
+	}
+
+	// パスワードが一致しない
+	comparePasswordErr := util.ComparePassword(user.Password, input.Password)
+	if comparePasswordErr != nil {
+		errorCode <- "LOGIN_WRONG_PASSWORD_403"
+		return &user, <-errorCode
+	}
+
+	errorCode <- "nil"
+	return &user, <-errorCode
+}

--- a/controllers/user/login/service.go
+++ b/controllers/user/login/service.go
@@ -1,0 +1,29 @@
+package loginAuth
+
+import (
+	model "github.com/Yuki-TU/todo-go/models"
+)
+
+type Service interface {
+	LoginService(input *InputLogin) (*model.EntityUsers, string)
+}
+
+type service struct {
+	repository Repository
+}
+
+func NewServiceLogin(repository Repository) *service {
+	return &service{repository: repository}
+}
+
+// 入力要素を整形し、リポジトリにつなげr
+func (s *service) LoginService(input *InputLogin) (*model.EntityUsers, string) {
+	user := model.EntityUsers{
+		Email:    input.Email,
+		Password: input.Password,
+	}
+
+	resultLogin, errLogin := s.repository.LoginRepository(&user)
+
+	return resultLogin, errLogin
+}

--- a/controllers/user/register/service.go
+++ b/controllers/user/register/service.go
@@ -30,6 +30,8 @@ func (s *service) RegisterService(input *InputRegister) (*model.EntityUsers, str
 		Password: input.Password,
 	}
 
+	users.HandleBeforeCreateUser()
+
 	resultRegister, errRegister := s.repository.RegisterRepository(&users)
 	return resultRegister, errRegister
 }

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.19
 require (
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.8.1
+	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/joho/godotenv v1.4.0
 	github.com/sirupsen/logrus v1.9.0
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 )
 
 require (
@@ -27,7 +29,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.3 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 	golang.org/x/net v0.0.0-20220812174116-3211cb980234 // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.1.0 h1:XUgk2Ex5veyVFVeLm0xhusUTQybEbexJXrvPNOKkSY0=
 github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-migrate/migrate/v4 v4.15.2 h1:vU+M05vs6jWHKDdmE1Ecwj0BznygFc4QsdRe2E/L7kc=
 github.com/golang-migrate/migrate/v4 v4.15.2/go.mod h1:f2toGLkYqD3JH+Todi4aZ2ZdbeUNx4sIwiOK96rE9Lw=

--- a/handlers/users/list/getList.go
+++ b/handlers/users/list/getList.go
@@ -1,0 +1,44 @@
+package userList
+
+import (
+	"net/http"
+
+	userList "github.com/Yuki-TU/todo-go/controllers/user/getList"
+	util "github.com/Yuki-TU/todo-go/utils"
+	"github.com/gin-gonic/gin"
+)
+
+type handler struct {
+	service userList.Service
+}
+
+func NewHandlerUserList(service userList.Service) *handler {
+	return &handler{service: service}
+}
+
+// ユーザ情報一覧取得
+// @params ctx コンテキスト
+func (h *handler) GetUserListHandler(ctx *gin.Context) {
+	// Authorizationヘッダーの確認
+	if ctx.GetHeader("Authorization") == "" {
+		util.APIResponse(ctx, "Authorization is required for this endpoint", http.StatusUnauthorized, http.MethodGet, nil)
+		return
+	}
+
+	// JWT認証確認
+	_, err := util.VerifyTokenHeader(ctx, "JWT_SECRET")
+	if err != nil {
+		util.APIResponse(ctx, "Verified activation token failed", http.StatusUnauthorized, http.MethodGet, nil)
+		return
+	}
+
+	// ユーザ一覧取得
+	userList, errUserList := h.service.GetUserListService()
+	switch errUserList {
+	case "USERLIST_NOT_FOUND_404":
+		util.APIResponse(ctx, "user list is not found", http.StatusNotFound, http.MethodGet, nil)
+		return
+	default:
+		util.APIResponse(ctx, "successfully", http.StatusOK, http.MethodGet, userList)
+	}
+}

--- a/handlers/users/login/login.go
+++ b/handlers/users/login/login.go
@@ -1,0 +1,49 @@
+package login
+
+import (
+	"net/http"
+
+	loginAuth "github.com/Yuki-TU/todo-go/controllers/user/login"
+	util "github.com/Yuki-TU/todo-go/utils"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+type handler struct {
+	service loginAuth.Service
+}
+
+func NewHandlerLogin(service loginAuth.Service) *handler {
+	return &handler{service: service}
+}
+
+// ログイン処理
+// @params ctx ginコンテキスト
+func (h *handler) LoginHandler(ctx *gin.Context) {
+	var input loginAuth.InputLogin
+	ctx.ShouldBindJSON(&input)
+
+	resultLogin, errLogin := h.service.LoginService(&input)
+
+	switch errLogin {
+	case "LOGIN_NOT_FOUND_404":
+		util.APIResponse(ctx, "User account is not registered", http.StatusNotFound, http.MethodPost, nil)
+		return
+
+	case "LOGIN_WRONG_PASSWORD_403":
+		util.APIResponse(ctx, "Username or password is wrong", http.StatusForbidden, http.MethodPost, nil)
+		return
+
+	default:
+		accessTokenData := map[string]interface{}{"id": resultLogin.ID, "email": resultLogin.Email}
+		accessToken, errToken := util.Sign(accessTokenData, "JWT_SECRET", 24*60*1)
+
+		if errToken != nil {
+			defer logrus.Error(errToken.Error())
+			util.APIResponse(ctx, "Generate accessToken failed", http.StatusBadRequest, http.MethodPost, nil)
+			return
+		}
+
+		util.APIResponse(ctx, "Login successfully", http.StatusOK, http.MethodPost, map[string]string{"accessToken": accessToken})
+	}
+}

--- a/models/entity.auth.go
+++ b/models/entity.auth.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"time"
+
+	util "github.com/Yuki-TU/todo-go/utils"
 )
 
 // データベースで扱っているユーザテーブル
@@ -13,4 +15,11 @@ type EntityUsers struct {
 	Active    bool   `gorm:"type:bool;default:false"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+// アカウント作成前にする処理
+// * パスワードハッシュ化
+func (entity *EntityUsers) HandleBeforeCreateUser() error {
+	entity.Password = util.HashPassword(entity.Password)
+	return nil
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -3,8 +3,10 @@ package routers
 import (
 	"database/sql"
 
+	loginAuth "github.com/Yuki-TU/todo-go/controllers/user/login"
 	registerAuth "github.com/Yuki-TU/todo-go/controllers/user/register"
 	handlerRegister "github.com/Yuki-TU/todo-go/handlers/users"
+	handlerLogin "github.com/Yuki-TU/todo-go/handlers/users/login"
 	"github.com/gin-gonic/gin"
 )
 
@@ -16,6 +18,10 @@ func SetRouting(db *sql.DB, router *gin.Engine) {
 	registerService := registerAuth.NewServiceRegister(registerRepository)
 	registerHandler := handlerRegister.NewHandlerRegister(registerService)
 
+	loginRepository := loginAuth.NewRepositoryLogin(db)
+	loginService := loginAuth.NewServiceLogin(loginRepository)
+	loginHandler := handlerLogin.NewHandlerLogin(loginService)
+
 	groupRoute := router.Group("/api/v1")
 	groupRoute.GET("", func(c *gin.Context) {
 		c.JSON(200, gin.H{
@@ -23,4 +29,5 @@ func SetRouting(db *sql.DB, router *gin.Engine) {
 		})
 	})
 	groupRoute.POST("/users", registerHandler.RegisterHandler)
+	groupRoute.POST("/login", loginHandler.LoginHandler)
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -3,10 +3,13 @@ package routers
 import (
 	"database/sql"
 
+	userList "github.com/Yuki-TU/todo-go/controllers/user/getList"
 	loginAuth "github.com/Yuki-TU/todo-go/controllers/user/login"
 	registerAuth "github.com/Yuki-TU/todo-go/controllers/user/register"
-	handlerRegister "github.com/Yuki-TU/todo-go/handlers/users"
+	handlerUserList "github.com/Yuki-TU/todo-go/handlers/users/list"
 	handlerLogin "github.com/Yuki-TU/todo-go/handlers/users/login"
+	handlerRegister "github.com/Yuki-TU/todo-go/handlers/users/register"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -22,12 +25,12 @@ func SetRouting(db *sql.DB, router *gin.Engine) {
 	loginService := loginAuth.NewServiceLogin(loginRepository)
 	loginHandler := handlerLogin.NewHandlerLogin(loginService)
 
+	userListRepository := userList.NewRepositoryUserList(db)
+	userListService := userList.NewServiceRegister(userListRepository)
+	userListHandler := handlerUserList.NewHandlerUserList(userListService)
+
 	groupRoute := router.Group("/api/v1")
-	groupRoute.GET("", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"message": "Hello World",
-		})
-	})
 	groupRoute.POST("/users", registerHandler.RegisterHandler)
+	groupRoute.GET("/users", userListHandler.GetUserListHandler)
 	groupRoute.POST("/login", loginHandler.LoginHandler)
 }

--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -18,9 +18,73 @@ paths:
   ## REGISTER AUTH ENDPOINT
   ############################
   /users:
+    get:
+      security:
+        - bearerAuth: []
+      tags:
+        - User
+      summary: ユーザ一覧取得
+      description: |
+        ユーザ一覧取得します。
+        全権取得する。
+      responses:
+        '200':
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: integer
+                    format: number
+                    example: 200
+                  method:
+                    type: string
+                    example: "GET"
+                  message:
+                    type: string
+                    example: "get user list successfully"
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        ID:
+                          type: integer
+                          example: 1
+                        Fullname:
+                          type: string
+                          example: "太郎"
+                        Email:
+                          type: string
+                          example: "taro@gmail.com"
+                        Active:
+                          type: boolean
+                          example: false
+                        CreatedAt:
+                          type: string
+                          example: "2022-09-11T16:13:47+09:00"
+                        UpdatedAt:
+                          type: string
+                          example: "2022-09-11T16:13:47+09:00"
+                required:
+                  - statusCode
+                  - method
+                  - message
+        '401':
+         $ref: '#/components/responses/401UnauthorizedError'
+        '404':
+          description: |
+            ユーザ一覧が取得できませんでした。
+            ユーザが存在しない。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404Error'
     post:
       tags:
-        - Auth Endpoint
+        - User
       summary: 認証して登録
       description: register new users account
       requestBody:
@@ -65,7 +129,10 @@ paths:
                     example: "Register new account successfully"
                   data:
                     type: object
-                    example: null
+                    properties:
+                      accessToken:
+                        type: string
+                        example:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemF0aW9uIjp0cnVlLCJlbWFpbCI6ImZ1amltb3RvX2RhaWdvQGdtYWlsLmNvbSIsImV4cCI6MTY2MzI2NzExMCwiaWQiOjB9.ULejQB0o7qKu50I-tlrzCBeJIv4v1fpqP7GQOPwNPJ4"
                 required:
                   - statusCode
                   - method
@@ -140,7 +207,35 @@ paths:
   ## COMPONENTS AUTH TERITORY
   #################################
   #################################
+
 components:
+  securitySchemes:
+    bearerAuth:            # arbitrary name for the security scheme
+      type: http
+      scheme: bearer
+      bearerFormat: JWT 
+  responses:
+    401UnauthorizedError:
+      description: |
+        認証失敗
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              statusCode:
+                type: integer
+                format: int64
+                example: "400"
+              method:
+                type: string
+                example: "GET"
+              message: 
+                type: string
+                example: "認証に失敗しました。"    
+              data:
+                type: object
+                example: null
   schemas:
     400Error:
       type: object
@@ -168,6 +263,9 @@ components:
         message: 
           type: string
           example: "無効なリクエストです。"
+        data:
+          type: object
+          example: null
 externalDocs:
   description: "Find more about Swagger"
   url: "http://swagger.io"

--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -207,6 +207,88 @@ paths:
   ## COMPONENTS AUTH TERITORY
   #################################
   #################################
+  /login:
+    post:
+      tags:
+        - login
+      summary: ログイン認証
+      description: |
+        ログイン認証して、アクセストークンを発行
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: fujimoto@gmail.com
+                password:
+                  type: string
+                  format: password
+                  example: qwerty123456789
+      responses:
+        '201':
+          description: 登録成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: integer
+                    format: number
+                    example: 201
+                  method:
+                    type: string
+                    example: "POST"
+                  message:
+                    type: string
+                    example: "Register new account successfully"
+                  data:
+                    type: object
+                    properties:
+                      accessToken:
+                        type: string
+                        example:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemF0aW9uIjp0cnVlLCJlbWFpbCI6ImZ1amltb3RvX2RhaWdvQGdtYWlsLmNvbSIsImV4cCI6MTY2MzI2NzExMCwiaWQiOjB9.ULejQB0o7qKu50I-tlrzCBeJIv4v1fpqP7GQOPwNPJ4"
+                required:
+                  - statusCode
+                  - method
+                  - message
+        '403':
+          description: |
+            パスワードが間違っている
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: integer
+                    format: number
+                    example: 403
+                  method:
+                    type: string
+                    example: "POST"
+                  message:
+                    type: string
+                    example: "Username or password is wrong"
+                  data:
+                    type: object
+                    example: null
+                required:
+                  - statusCode
+                  - method
+                  - message
+        '404':
+          description: |
+            アカウントが存在しない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404Error'
 
 components:
   securitySchemes:

--- a/utils/bcrypt.go
+++ b/utils/bcrypt.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// パスワードをハッシュ化する
+// @params password ハッシュ化したいパスワード
+//
+// @return ハッシュ化されたパスワード
+func HashPassword(password string) string {
+	hashPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		logrus.Fatal(err.Error())
+	}
+	return string(hashPassword)
+}
+
+// パスワードが一意するか判断する
+// @params hashPassword ハッシュ化されたパスワード
+//
+// @parasm password 比較対象のハッシュ化されていないパスワード
+//
+// @return 一致：nil, 一致しない: エラー
+func ComparePassword(hashPassword string, password string) error {
+	err := bcrypt.CompareHashAndPassword([]byte(hashPassword), []byte(password))
+	return err
+}

--- a/utils/jwt.go
+++ b/utils/jwt.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/sirupsen/logrus"
+)
+
+type MetaToken struct {
+	ID            string
+	Email         string
+	ExpiredAt     time.Time
+	Authorization bool
+}
+
+type AccessToken struct {
+	Claims MetaToken
+}
+
+// アクセストークンお発行する
+//
+// @params Clames Claimsで利用するデータ
+//
+// @params SecreublicKeyEnvName 署名作成に医療するシークレットキー
+//
+// @pramas expiredAt 有効期間(分)
+//
+// @returns accessToken, err アクセストークン, err
+func Sign(Claims map[string]interface{}, SecretPublicKeyEnvName string, ExpiredAt time.Duration) (string, error) {
+	jwtSecretKey := GodotEnv(SecretPublicKeyEnvName)
+
+	// clamsの作成
+	claims := jwt.MapClaims{}
+	expiredAt := time.Now().Add(time.Duration(time.Minute) * ExpiredAt).Unix()
+	claims["exp"] = expiredAt
+	claims["authorization"] = true
+	for index, claim := range Claims {
+		claims[index] = claim
+	}
+
+	// ヘッダーとペイロードの作成
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	accessToken, err := token.SignedString([]byte(jwtSecretKey))
+
+	if err != nil {
+		logrus.Error(err.Error())
+		return accessToken, err
+	}
+
+	return accessToken, nil
+}
+
+// リクエストヘッダーよりトークンを検証、解析する
+//
+// @paramas ctx ginコンテキスト
+//
+// @params SecretPublicKeyEnvName envに指定されたシークレットキー
+//
+// @return 解析されたトークン情報
+func VerifyTokenHeader(ctx *gin.Context, SecretPublicKeyEnvName string) (*jwt.Token, error) {
+	tokenHeader := ctx.GetHeader("Authorization")
+	accessToken := strings.SplitAfter(tokenHeader, "Bearer")[1]
+	jwtSecretKey := GodotEnv(SecretPublicKeyEnvName)
+
+	token, err := jwt.Parse(strings.Trim(accessToken, " "), func(token *jwt.Token) (interface{}, error) {
+		return []byte(jwtSecretKey), nil
+	})
+
+	if err != nil {
+		logrus.Error(err.Error())
+		return nil, err
+	}
+
+	return token, nil
+}


### PR DESCRIPTION
# issue
closes #5 

# 変更箇所
- JWTによる認証を実施
  - ただし、セッション管理はいていないため、ログアウトしてすぐトークンを向こうになることはない
  - 有効期限は指定している
  - 将来的にはリフレッシュトークンや従来のセッション管理方法であるスレートフルにせっっション管理を行う必要がある
- loginとサインアップ時にアクセストークンが発行される
- ユーザ一覧取得にはアクセストークンをヘッダーAuthorizationに付与しないと見れない

ユーザ一覧curlコマンド例

```sh
$ curl -X 'GET' \
  'http://localhost:8081/api/v1/users' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRob3JpemF0aW9uIjp0cnVlLCJlbWFpbCI6ImZ1amltb3RvQGdtYWlsLmNvbSIsImV4cCI6MTY2MzYwNzE0OCwiaWQiOjEzfQ.j8YZ0R0l5h8gfDs5p-vig5KvRmCIZI6yHk2mcag4E8w'
```

詳しくはswaggerを参照

